### PR TITLE
Use transaction requests instead of transactions

### DIFF
--- a/POSMerchant.xcodeproj/project.pbxproj
+++ b/POSMerchant.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		033802EC2161EC8D00C2501F /* QRReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033802EB2161EC8D00C2501F /* QRReaderViewModel.swift */; };
 		033802EE2161EEFC00C2501F /* QRReaderOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033802ED2161EEFC00C2501F /* QRReaderOverlayView.swift */; };
 		033802F02161F48700C2501F /* QRReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033802EF2161F48700C2501F /* QRReader.swift */; };
+		0341BCB5216DE56F001928FE /* WaitingForUserConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0341BCB4216DE56F001928FE /* WaitingForUserConfirmationViewController.swift */; };
 		03467AB32165E9F700A33064 /* KeypadInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03467AB22165E9F700A33064 /* KeypadInputViewController.swift */; };
 		03467AB52165EA9A00A33064 /* ReceiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03467AB42165EA9A00A33064 /* ReceiveViewModel.swift */; };
 		03467AB72165EF6A00A33064 /* TopUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03467AB62165EF6A00A33064 /* TopUpViewModel.swift */; };
@@ -188,6 +189,7 @@
 		033802EB2161EC8D00C2501F /* QRReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRReaderViewModel.swift; sourceTree = "<group>"; };
 		033802ED2161EEFC00C2501F /* QRReaderOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRReaderOverlayView.swift; sourceTree = "<group>"; };
 		033802EF2161F48700C2501F /* QRReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRReader.swift; sourceTree = "<group>"; };
+		0341BCB4216DE56F001928FE /* WaitingForUserConfirmationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingForUserConfirmationViewController.swift; sourceTree = "<group>"; };
 		03467AB22165E9F700A33064 /* KeypadInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeypadInputViewController.swift; sourceTree = "<group>"; };
 		03467AB42165EA9A00A33064 /* ReceiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveViewModel.swift; sourceTree = "<group>"; };
 		03467AB62165EF6A00A33064 /* TopUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopUpViewModel.swift; sourceTree = "<group>"; };
@@ -422,6 +424,7 @@
 				0354DDFB2166175E009D9E7B /* MoreTableViewController.swift */,
 				0354DDFD216617BD009D9E7B /* TouchIDConfirmationViewController.swift */,
 				0354DE0721673D00009D9E7B /* TransactionsViewController.swift */,
+				0341BCB4216DE56F001928FE /* WaitingForUserConfirmationViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -780,6 +783,7 @@
 				03E0BB472164821800FCB154 /* TransactionResultViewController.swift in Sources */,
 				032BACAB2165CE7E00D63EBC /* TabBarViewController.swift in Sources */,
 				03C94B4B215B441F007DF271 /* AccountCellViewModel.swift in Sources */,
+				0341BCB5216DE56F001928FE /* WaitingForUserConfirmationViewController.swift in Sources */,
 				0306DC97215A28C100612953 /* Publisher.swift in Sources */,
 				0306DCAA215A352500612953 /* SigninViewModel.swift in Sources */,
 				03467ABD2165F3A000A33064 /* TopupViewController.swift in Sources */,

--- a/POSMerchant.xcodeproj/project.pbxproj
+++ b/POSMerchant.xcodeproj/project.pbxproj
@@ -700,7 +700,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-POSMerchant/Pods-POSMerchant-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-POSMerchant/Pods-POSMerchant-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/AlamofireImage/AlamofireImage.framework",
 				"${BUILT_PRODUCTS_DIR}/BigInt/BigInt.framework",
@@ -729,7 +729,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-POSMerchant/Pods-POSMerchant-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-POSMerchant/Pods-POSMerchant-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/POSMerchant/Base.lproj/Localizable.strings
+++ b/POSMerchant/Base.lproj/Localizable.strings
@@ -90,7 +90,11 @@
 "more.view.title" = "More";
 "more.label.transactions" = "Transactions";
 "more.label.account" = "Account";
+"more.label.exchange_account" = "Exchange account";
 "more.label.signout" = "Sign out";
+"more.section.settings" = "Settings";
+"more.section.info" = "Info";
+"more.label.version" = "Version";
 
 // TouchID confirmation
 "touch_id_confirmation.view.title" = "Confirm your password";

--- a/POSMerchant/Base.lproj/Localizable.strings
+++ b/POSMerchant/Base.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "tab.more.title" = "More";
 
 // Keypad input
+"keypad_input.error.invalid_qr_code" = "The scanned QR code is not valid for this version of the application.";
 "keypad_input.error.no_token" = "There is no token available.";
 
 // Receive
@@ -69,7 +70,12 @@
 "transaction_confirmation.to" = "to";
 "transaction_confirmation.button.confirm" = "Confirm";
 "transaction_confirmation.button.cancel" = "Cancel";
-"transaction_confirmation.qrcode_error" = "The scanned QR code doesn't seem to be valid, please try again.";
+"transaction_confirmation.error.invalid_qr_code" = "The scanned QR code doesn't seem to be valid, please try again.";
+"transaction_cofirmation.error.user_rejected" = "The transaction has been cancelled";
+
+// Pending confirmation
+
+"waiting_confirmation.label.hint" = "Waiting for user's confirmation";
 
 // Transaction result
 "transaction_result.from" = "from";

--- a/POSMerchant/Helpers/BaseViewControllerProtocols.swift
+++ b/POSMerchant/Helpers/BaseViewControllerProtocols.swift
@@ -14,12 +14,12 @@ protocol Configurable {
     func configureViewModel()
 }
 
-protocol Loadable {
+protocol Loadable: class {
     var loading: MBProgressHUD? { get set }
 }
 
 extension Loadable where Self: UIViewController {
-    mutating func showLoading() {
+    func showLoading() {
         self.loading = MBProgressHUDBuilder.build(for: self)
     }
 

--- a/POSMerchant/Helpers/Constant.swift
+++ b/POSMerchant/Helpers/Constant.swift
@@ -12,6 +12,8 @@ enum UserDefaultKey: String {
     case email = "com.omisego.pos-merchant.email"
     case biometricEnabled = "com.omisego.pos-merchant.biometric_enabled"
     case accountId = "com.omisego.pos-merchant.selected_account_id"
+    case exchangeAccountId = "com.omisego.pos-merchant.exchange_account_id"
+    case exchangeAccountName = "com.omisego.pos-merchant.exchange_account_name"
 }
 
 enum KeychainKey: String {
@@ -23,6 +25,7 @@ enum KeychainKey: String {
 struct Constant {
     static let urlScheme = "pos-merchant://"
 
+//    static let baseURL = "http://192.168.1.42:4000"
     static let baseURL = "https://coffeego.omisego.io"
 
     // Pagination

--- a/POSMerchant/Helpers/OmiseGOWrapper.swift
+++ b/POSMerchant/Helpers/OmiseGOWrapper.swift
@@ -53,18 +53,18 @@ class WalletLoader: WalletLoaderProtocol {
     }
 }
 
-protocol TransactionGeneratorProtocol {
+protocol TransactionConsumptionGeneratorProtocol {
     @discardableResult
-    func create(withParams params: TransactionCreateParams,
-                callback: @escaping Transaction.RetrieveRequestCallback) -> Transaction.RetrieveRequest?
+    func consume(withParams params: TransactionConsumptionParams,
+                 callback: @escaping TransactionConsumption.RetrieveRequestCallback) -> TransactionConsumption.RetrieveRequest?
 }
 
 /// This wrapper has been created for the sake of testing with dependency injection
-class TransactionGenerator: TransactionGeneratorProtocol {
+class TransactionConsumptionGenerator: TransactionConsumptionGeneratorProtocol {
     @discardableResult
-    func create(withParams params: TransactionCreateParams,
-                callback: @escaping Transaction.RetrieveRequestCallback) -> Transaction.RetrieveRequest? {
-        return Transaction.create(using: SessionManager.shared.httpClient, params: params, callback: callback)
+    func consume(withParams params: TransactionConsumptionParams,
+                 callback: @escaping TransactionConsumption.RetrieveRequestCallback) -> TransactionConsumption.RetrieveRequest? {
+        return TransactionConsumption.consumeTransactionRequest(using: SessionManager.shared.httpClient, params: params, callback: callback)
     }
 }
 

--- a/POSMerchant/Managers/SessionManager.swift
+++ b/POSMerchant/Managers/SessionManager.swift
@@ -141,10 +141,19 @@ class SessionManager: Publisher, SessionManagerProtocol {
             switch response {
             case let .success(data: account):
                 self.selectedAccount = account
+                self.setDefaultExchangeAccount(withAccount: account)
             case let .fail(error: error):
                 failure(error)
             }
         }
+    }
+
+    private func setDefaultExchangeAccount(withAccount account: Account) {
+        guard self.userDefaultsWrapper.getValue(forKey: .exchangeAccountId) == nil else {
+            return
+        }
+        self.userDefaultsWrapper.storeValue(value: account.id, forKey: .exchangeAccountId)
+        self.userDefaultsWrapper.storeValue(value: account.name, forKey: .exchangeAccountName)
     }
 
     private func setupOmiseGOClients() {
@@ -179,6 +188,8 @@ class SessionManager: Publisher, SessionManagerProtocol {
 
     private func clearTokens() {
         self.userDefaultsWrapper.clearValue(forKey: .accountId)
+        self.userDefaultsWrapper.clearValue(forKey: .exchangeAccountId)
+        self.userDefaultsWrapper.clearValue(forKey: .exchangeAccountName)
         self.keychainWrapper.clearValue(forKey: .authenticationToken)
         self.keychainWrapper.clearValue(forKey: .userId)
         self.selectedAccount = nil

--- a/POSMerchant/Managers/SessionManager.swift
+++ b/POSMerchant/Managers/SessionManager.swift
@@ -107,7 +107,7 @@ class SessionManager: Publisher, SessionManagerProtocol {
                 self.keychainWrapper.storeValue(value: authenticationToken.token, forKey: .authenticationToken)
                 self.keychainWrapper.storeValue(value: authenticationToken.user.id, forKey: .userId)
                 self.userDefaultsWrapper.storeValue(value: params.email, forKey: .email)
-                self.socketClient.updateConfiguration(self.retriveConfigurationFromStorage())
+                self.socketClient.updateConfiguration(self.retrieveConfigurationFromStorage())
                 success()
             }
         }
@@ -157,12 +157,12 @@ class SessionManager: Publisher, SessionManagerProtocol {
     }
 
     private func setupOmiseGOClients() {
-        let config = self.retriveConfigurationFromStorage()
+        let config = self.retrieveConfigurationFromStorage()
         self.httpClient = HTTPAdminAPI(config: config)
         self.socketClient = SocketClient(config: config, delegate: nil)
     }
 
-    private func retriveConfigurationFromStorage() -> AdminConfiguration {
+    private func retrieveConfigurationFromStorage() -> AdminConfiguration {
         if let authenticationToken = self.keychainWrapper.getValue(forKey: .authenticationToken),
             let userId = self.keychainWrapper.getValue(forKey: .userId) {
             let credentials = AdminCredential(userId: userId, authenticationToken: authenticationToken)

--- a/POSMerchant/Managers/SessionManager.swift
+++ b/POSMerchant/Managers/SessionManager.swift
@@ -69,6 +69,7 @@ class SessionManager: Publisher, SessionManagerProtocol {
     func selectCurrentAccount(_ account: Account) {
         self.userDefaultsWrapper.storeValue(value: account.id, forKey: .accountId)
         self.selectedAccount = account
+        self.setDefaultExchangeAccount(withAccount: account)
     }
 
     func disableBiometricAuth() {

--- a/POSMerchant/Models/TransactionBuilder.swift
+++ b/POSMerchant/Models/TransactionBuilder.swift
@@ -12,39 +12,32 @@ struct TransactionBuilder {
     let type: TransactionType
     let amount: String
     let token: Token
-    let address: String
+    let transactionRequestFormattedId: String
 
     var user: User?
-    var result: Response<Transaction>?
+    var transactionConsumption: TransactionConsumption?
+    var error: POSMerchantError?
 
-    init(type: TransactionType, amount: String, token: Token, address: String) {
+    init?(type: TransactionType, amount: String, token: Token, decodedString: String) {
+        let splittedIds = decodedString.split(separator: "|")
+        guard splittedIds.count == 2 else { return nil }
+        switch type {
+        case .topup: self.transactionRequestFormattedId = String(splittedIds[0])
+        case .receive: self.transactionRequestFormattedId = String(splittedIds[1])
+        }
         self.type = type
         self.amount = amount
         self.token = token
-        self.address = address
     }
 
-    func params(forAccount account: Account, idemPotencyToken: String) -> TransactionCreateParams {
+    func params(forAccount account: Account, idemPotencyToken: String) -> TransactionConsumptionParams {
         let formattedAmount = OMGNumberFormatter().number(from: self.amount,
                                                           subunitToUnit: self.token.subUnitToUnit)
-        return TransactionCreateParams(fromAddress: self.type == .receive ? self.address : nil,
-                                       toAddress: self.type == .topup ? self.address : nil,
-                                       amount: formattedAmount,
-                                       fromAmount: nil,
-                                       toAmount: nil,
-                                       fromTokenId: nil,
-                                       toTokenId: nil,
-                                       tokenId: self.token.id,
-                                       fromAccountId: self.type == .topup ? account.id : nil,
-                                       toAccountId: self.type == .receive ? account.id : nil,
-                                       fromProviderUserId: nil,
-                                       toProviderUserId: nil,
-                                       fromUserId: nil,
-                                       toUserId: nil,
-                                       idempotencyToken: idemPotencyToken,
-                                       exchangeAccountId: nil,
-                                       exchangeAddress: nil,
-                                       metadata: [:],
-                                       encryptedMetadata: [:])
+        return TransactionConsumptionParams(formattedTransactionRequestId: self.transactionRequestFormattedId,
+                                            accountId: account.id,
+                                            amount: formattedAmount,
+                                            idempotencyToken: idemPotencyToken,
+                                            tokenId: self.token.id,
+                                            exchangeAccountId: account.id)
     }
 }

--- a/POSMerchant/Models/TransactionBuilder.swift
+++ b/POSMerchant/Models/TransactionBuilder.swift
@@ -38,6 +38,6 @@ struct TransactionBuilder {
                                             amount: formattedAmount,
                                             idempotencyToken: idemPotencyToken,
                                             tokenId: self.token.id,
-                                            exchangeAccountId: account.id)
+                                            exchangeAccountId: UserDefaultsWrapper().getValue(forKey: .exchangeAccountId))
     }
 }

--- a/POSMerchant/Storyboards/Base.lproj/Keyboard.storyboard
+++ b/POSMerchant/Storyboards/Base.lproj/Keyboard.storyboard
@@ -32,7 +32,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="7">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="7Ms-1a-Z9w"/>
@@ -55,7 +55,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="8">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="3r3-CD-f3Y"/>
@@ -78,7 +78,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="9">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="5iP-Bv-aHl"/>
@@ -106,7 +106,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="4">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="Drb-bq-4KB"/>
@@ -129,7 +129,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="5">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="MYk-5K-xgA"/>
@@ -152,7 +152,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="6">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="S0X-UI-6GW"/>
@@ -180,7 +180,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="1">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="RsQ-3s-ScG"/>
@@ -203,7 +203,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="2">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="Ao6-Kj-RIW"/>
@@ -226,7 +226,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="3">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="PY1-aD-e99"/>
@@ -254,7 +254,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title=".">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapDecimalSeparatorButton:" destination="nXM-6G-vrT" eventType="touchUpInside" id="KUY-GP-dCf"/>
@@ -277,7 +277,7 @@
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                         <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                                         <state key="normal" title="0">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumber:" destination="nXM-6G-vrT" eventType="touchUpInside" id="tOE-mo-pYR"/>
@@ -297,9 +297,9 @@
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qwV-X1-ufw">
                                                         <rect key="frame" x="0.0" y="0.0" width="125" height="93.5"/>
-                                                        <color key="tintColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <state key="normal" image="Delete">
-                                                            <color key="titleColor" red="0.52156862745098043" green="0.54509803921568623" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="didTapNumberButton:" destination="nXM-6G-vrT" eventType="touchUpInside" id="GNa-Tb-wMN"/>

--- a/POSMerchant/Storyboards/Base.lproj/More.storyboard
+++ b/POSMerchant/Storyboards/Base.lproj/More.storyboard
@@ -38,10 +38,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
-                            <tableViewSection id="MEr-IC-XiX">
+                            <tableViewSection headerTitle="Settings" id="MEr-IC-XiX">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="47z-Ae-ilc" detailTextLabel="9oD-NE-fru" imageView="gXZ-eC-c8y" style="IBUITableViewCellStyleValue1" id="T1x-5V-Gxj">
-                                        <rect key="frame" x="0.0" y="35" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="T1x-5V-Gxj" id="wjo-am-n3Y">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
@@ -69,8 +69,37 @@
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.23529411764705882" green="0.25490196078431371" blue="0.30196078431372547" alpha="1" colorSpace="calibratedRGB"/>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="xa3-WQ-9vx" detailTextLabel="nUv-C6-tJl" imageView="vBS-xD-Mlj" style="IBUITableViewCellStyleValue1" id="Ve3-Kp-8AN">
+                                        <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ve3-Kp-8AN" id="e4J-6Q-duy">
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Exchange Account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xa3-WQ-9vx">
+                                                    <rect key="frame" x="60" y="10" width="143.5" height="23.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nUv-C6-tJl">
+                                                    <rect key="frame" x="295" y="10" width="45" height="23.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="17"/>
+                                                    <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="Account" id="vBS-xD-Mlj">
+                                                    <rect key="frame" x="16" y="7" width="29" height="29"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                </imageView>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="tintColor" red="0.23529411759999999" green="0.25490196079999999" blue="0.30196078430000001" alpha="1" colorSpace="calibratedRGB"/>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Nex-G1-7X1" imageView="KYd-A5-jpL" style="IBUITableViewCellStyleDefault" id="nXk-fB-nxk">
-                                        <rect key="frame" x="0.0" y="79" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nXk-fB-nxk" id="Gfz-Dy-d7E">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
@@ -92,14 +121,14 @@
                                         <color key="tintColor" red="0.23529411764705882" green="0.25490196078431371" blue="0.30196078431372547" alpha="1" colorSpace="calibratedRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="roH-b2-jO1">
-                                        <rect key="frame" x="0.0" y="123" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="187.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="roH-b2-jO1" id="pCM-nB-mBj">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Touch ID/Face ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VB6-vC-nyN">
-                                                    <rect key="frame" x="16" y="0.0" width="286" height="43.5"/>
+                                                    <rect key="frame" x="60" y="0.0" width="242" height="43.5"/>
                                                     <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -114,7 +143,7 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="VB6-vC-nyN" firstAttribute="top" secondItem="pCM-nB-mBj" secondAttribute="top" id="G9u-OA-dyr"/>
-                                                <constraint firstItem="VB6-vC-nyN" firstAttribute="leading" secondItem="pCM-nB-mBj" secondAttribute="leading" constant="16" id="Zin-Fh-RWr"/>
+                                                <constraint firstItem="VB6-vC-nyN" firstAttribute="leading" secondItem="pCM-nB-mBj" secondAttribute="leading" constant="60" id="Zin-Fh-RWr"/>
                                                 <constraint firstAttribute="trailing" secondItem="8H9-j4-tjw" secondAttribute="trailing" constant="16" id="kr2-qL-zKQ"/>
                                                 <constraint firstItem="8H9-j4-tjw" firstAttribute="leading" secondItem="VB6-vC-nyN" secondAttribute="trailing" constant="8" id="mdn-EM-pcI"/>
                                                 <constraint firstAttribute="bottom" secondItem="VB6-vC-nyN" secondAttribute="bottom" id="rS6-Vu-DMU"/>
@@ -122,15 +151,19 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Info" id="xmw-3I-twG">
+                                <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="Qj3-8G-Sfg" detailTextLabel="peR-xy-Cmn" imageView="GPp-Da-cNg" style="IBUITableViewCellStyleValue1" id="erP-HG-KmG">
-                                        <rect key="frame" x="0.0" y="167" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="287.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="erP-HG-KmG" id="VKS-mm-adW">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Qj3-8G-Sfg">
-                                                    <rect key="frame" x="16" y="10" width="5" height="23.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text=" Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Qj3-8G-Sfg">
+                                                    <rect key="frame" x="16" y="10" width="61.5" height="23.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -153,16 +186,16 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection id="xmw-3I-twG">
+                            <tableViewSection id="1md-fQ-H6m">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="DPf-6d-8m3" style="IBUITableViewCellStyleDefault" id="fh3-eZ-5jI">
-                                        <rect key="frame" x="0.0" y="247" width="375" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="1Pp-D2-jRq" style="IBUITableViewCellStyleDefault" id="gXp-NR-t3t">
+                                        <rect key="frame" x="0.0" y="367.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fh3-eZ-5jI" id="Ci7-gg-RfQ">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gXp-NR-t3t" id="vG3-C6-TON">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Sign out" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DPf-6d-8m3">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Sign out" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1Pp-D2-jRq">
                                                     <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="17"/>
@@ -184,14 +217,18 @@
                     <connections>
                         <outlet property="accountLabel" destination="47z-Ae-ilc" id="FIc-12-Kw4"/>
                         <outlet property="accountValueLabel" destination="9oD-NE-fru" id="y2V-ch-c2G"/>
-                        <outlet property="signOutLabel" destination="DPf-6d-8m3" id="bOk-nd-jQV"/>
-                        <outlet property="touchFaceIdLabel" destination="VB6-vC-nyN" id="WUj-k5-dE1"/>
+                        <outlet property="exchangeAccountLabel" destination="xa3-WQ-9vx" id="AZm-yH-pbI"/>
+                        <outlet property="exchangeAccountValueLabel" destination="nUv-C6-tJl" id="lVC-Ut-Btp"/>
+                        <outlet property="signOutLabel" destination="1Pp-D2-jRq" id="kIS-sh-mqy"/>
+                        <outlet property="touchFaceIdLabel" destination="VB6-vC-nyN" id="aMo-mP-AM5"/>
                         <outlet property="touchFaceIdSwitch" destination="8H9-j4-tjw" id="c7S-0f-50o"/>
                         <outlet property="transactionLabel" destination="Nex-G1-7X1" id="oYE-GI-Nxo"/>
-                        <outlet property="versionLabel" destination="peR-xy-Cmn" id="nGw-ES-Fal"/>
+                        <outlet property="versionLabel" destination="Qj3-8G-Sfg" id="aEf-X7-ZM4"/>
+                        <outlet property="versionValueLabel" destination="peR-xy-Cmn" id="ea3-mP-s6I"/>
                         <segue destination="xq1-PC-868" kind="show" identifier="showTouchIdConfirmationViewController" id="tJC-1l-AQp"/>
                         <segue destination="Fda-PQ-DOH" kind="show" identifier="showTransactionsViewController" id="2g8-mQ-0gr"/>
                         <segue destination="iv1-5T-scF" kind="show" identifier="showAccountsViewController" id="eOD-W5-RzN"/>
+                        <segue destination="LgH-QZ-GBz" kind="show" identifier="showExchangeAccountsViewController" id="9Rg-mZ-Fd4"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pC9-an-dFp" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -361,6 +398,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Dzn-cr-CN7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1022" y="185"/>
+        </scene>
+        <!--SelectAccountTableViewController-->
+        <scene sceneID="IDq-kP-KoT">
+            <objects>
+                <viewControllerPlaceholder storyboardName="AccountSelection" referencedIdentifier="SelectAccountTableViewController" id="LgH-QZ-GBz" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3mM-1R-q4X" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1021" y="301"/>
         </scene>
     </scenes>
     <resources>

--- a/POSMerchant/Storyboards/Base.lproj/Transaction.storyboard
+++ b/POSMerchant/Storyboards/Base.lproj/Transaction.storyboard
@@ -62,7 +62,7 @@
                                 <rect key="frame" x="16" y="36" width="288" height="352"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f9N-Vw-feh">
-                                        <rect key="frame" x="0.0" y="39.5" width="288" height="273"/>
+                                        <rect key="frame" x="0.0" y="30" width="288" height="292.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RM4-Qt-fem">
                                                 <rect key="frame" x="0.0" y="0.0" width="288" height="36"/>
@@ -75,29 +75,35 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="from" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pg2-fo-pyc">
-                                                <rect key="frame" x="0.0" y="163" width="288" height="23"/>
+                                                <rect key="frame" x="0.0" y="182.5" width="288" height="23"/>
                                                 <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="17"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X1N-DZ-wY8">
-                                                <rect key="frame" x="0.0" y="194" width="288" height="47"/>
+                                                <rect key="frame" x="0.0" y="213.5" width="288" height="47"/>
                                                 <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="34"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r6j-ka-JrB">
-                                                <rect key="frame" x="0.0" y="249" width="288" height="24"/>
+                                                <rect key="frame" x="0.0" y="268.5" width="288" height="24"/>
                                                 <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="17"/>
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="(0 TKN)" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMq-C8-2tO">
+                                                <rect key="frame" x="0.0" y="123" width="288" height="19.5"/>
+                                                <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="14"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="X1N-DZ-wY8" secondAttribute="trailing" id="3gR-gM-FaL"/>
+                                            <constraint firstItem="nMq-C8-2tO" firstAttribute="top" secondItem="LSn-8I-C88" secondAttribute="bottom" id="6CQ-9W-a7q"/>
                                             <constraint firstItem="Pg2-fo-pyc" firstAttribute="leading" secondItem="f9N-Vw-feh" secondAttribute="leading" id="6J4-KY-qqz"/>
                                             <constraint firstAttribute="trailing" secondItem="r6j-ka-JrB" secondAttribute="trailing" id="In2-LN-wwY"/>
-                                            <constraint firstItem="Pg2-fo-pyc" firstAttribute="top" secondItem="LSn-8I-C88" secondAttribute="bottom" constant="40" id="Jfd-9E-0SW"/>
                                             <constraint firstAttribute="bottom" secondItem="r6j-ka-JrB" secondAttribute="bottom" id="JuM-cn-9fz"/>
+                                            <constraint firstItem="Pg2-fo-pyc" firstAttribute="top" secondItem="nMq-C8-2tO" secondAttribute="bottom" constant="40" id="LIG-Ac-rv5"/>
                                             <constraint firstItem="r6j-ka-JrB" firstAttribute="top" secondItem="X1N-DZ-wY8" secondAttribute="bottom" constant="8" id="PU8-f5-lxp"/>
                                             <constraint firstItem="X1N-DZ-wY8" firstAttribute="top" secondItem="Pg2-fo-pyc" secondAttribute="bottom" constant="8" id="VWQ-K6-eR9"/>
                                             <constraint firstItem="RM4-Qt-fem" firstAttribute="top" secondItem="f9N-Vw-feh" secondAttribute="top" id="XCP-sL-dc0"/>
@@ -107,6 +113,8 @@
                                             <constraint firstItem="X1N-DZ-wY8" firstAttribute="leading" secondItem="f9N-Vw-feh" secondAttribute="leading" id="fG4-vp-91v"/>
                                             <constraint firstItem="LSn-8I-C88" firstAttribute="top" secondItem="RM4-Qt-fem" secondAttribute="bottom" constant="40" id="kfU-9d-TdE"/>
                                             <constraint firstAttribute="trailing" secondItem="LSn-8I-C88" secondAttribute="trailing" id="l26-32-AKx"/>
+                                            <constraint firstItem="nMq-C8-2tO" firstAttribute="leading" secondItem="f9N-Vw-feh" secondAttribute="leading" id="ntx-tO-Ieo"/>
+                                            <constraint firstAttribute="trailing" secondItem="nMq-C8-2tO" secondAttribute="trailing" id="pF0-vt-bQF"/>
                                             <constraint firstItem="LSn-8I-C88" firstAttribute="leading" secondItem="f9N-Vw-feh" secondAttribute="leading" id="tsw-Oi-gGP"/>
                                             <constraint firstItem="r6j-ka-JrB" firstAttribute="leading" secondItem="f9N-Vw-feh" secondAttribute="leading" id="zn5-G7-Bb9"/>
                                         </constraints>
@@ -144,14 +152,16 @@
                         <outlet property="directionLabel" destination="Pg2-fo-pyc" id="5O6-u7-eJV"/>
                         <outlet property="titleLabel" destination="RM4-Qt-fem" id="0n3-vy-gcd"/>
                         <outlet property="tokenLabel" destination="LSn-8I-C88" id="DOf-Qg-geD"/>
+                        <outlet property="userDisplayAmount" destination="nMq-C8-2tO" id="QM4-Au-3Ki"/>
                         <outlet property="userIdLabel" destination="r6j-ka-JrB" id="R2a-Ro-MIi"/>
                         <outlet property="usernameLabel" destination="X1N-DZ-wY8" id="7VO-XP-OC6"/>
                         <segue destination="cnJ-6f-LSZ" kind="show" identifier="showTransactionResultSegueIdentifier" id="N3V-VS-pkm"/>
+                        <segue destination="d49-qy-S2R" kind="presentation" identifier="showPendingConfirmationSegueIdentifier" id="bgE-PC-Es9"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9rg-pe-V0t" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-980" y="150"/>
+            <point key="canvasLocation" x="-980.625" y="150"/>
         </scene>
         <!--Receive-->
         <scene sceneID="poW-BI-3q8">
@@ -290,7 +300,78 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KWr-SY-1v9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="437.68115942028987" y="150"/>
+            <point key="canvasLocation" x="1211" y="150"/>
+        </scene>
+        <!--Receive-->
+        <scene sceneID="egY-6w-LMe">
+            <objects>
+                <viewController storyboardIdentifier="WaitingForUserConfirmationViewController" hidesBottomBarWhenPushed="YES" id="d49-qy-S2R" customClass="WaitingForUserConfirmationViewController" customModule="POSMerchant" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Hhx-Cv-PGe">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Waiting for user confirmation" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="15f-PE-8sp">
+                                <rect key="frame" x="32" y="52" width="256" height="138"/>
+                                <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="26"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S6t-Wl-g2c">
+                                <rect key="frame" x="32" y="486" width="256" height="50"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="MfI-cL-Ep3"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="17"/>
+                                <color key="tintColor" red="0.1019607843" green="0.32549019610000002" blue="0.94117647059999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <inset key="imageEdgeInsets" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                <state key="normal" title="Cancel">
+                                    <color key="titleColor" red="0.93725490199999995" green="0.20784313730000001" blue="0.14901960780000001" alpha="1" colorSpace="calibratedRGB"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="tapCancelButton:" destination="d49-qy-S2R" eventType="touchUpInside" id="6dp-09-jej"/>
+                                    <action selector="tapCancelButton:" destination="nHT-EC-rlX" eventType="touchUpInside" id="hhd-BM-K63"/>
+                                </connections>
+                            </button>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="GO_1" translatesAutoresizingMaskIntoConstraints="NO" id="XuD-5u-8XF">
+                                <rect key="frame" x="98" y="222" width="124" height="124"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="124" id="D3U-dV-sR1"/>
+                                    <constraint firstAttribute="width" constant="124" id="fzV-h4-adH"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="S6t-Wl-g2c" firstAttribute="leading" secondItem="XxM-Qk-9Cl" secondAttribute="leading" constant="32" id="0sV-dH-GCL"/>
+                            <constraint firstItem="XuD-5u-8XF" firstAttribute="centerX" secondItem="Hhx-Cv-PGe" secondAttribute="centerX" id="R7v-wv-OeX"/>
+                            <constraint firstItem="XuD-5u-8XF" firstAttribute="top" secondItem="15f-PE-8sp" secondAttribute="bottom" constant="32" id="Rq2-hk-Ypy"/>
+                            <constraint firstItem="XxM-Qk-9Cl" firstAttribute="trailing" secondItem="S6t-Wl-g2c" secondAttribute="trailing" constant="32" id="YYC-Am-Ycx"/>
+                            <constraint firstItem="15f-PE-8sp" firstAttribute="leading" secondItem="Hhx-Cv-PGe" secondAttribute="leading" constant="32" id="b6F-U9-atG"/>
+                            <constraint firstItem="XxM-Qk-9Cl" firstAttribute="bottom" secondItem="S6t-Wl-g2c" secondAttribute="bottom" constant="32" id="luJ-o3-OcT"/>
+                            <constraint firstItem="15f-PE-8sp" firstAttribute="top" secondItem="XxM-Qk-9Cl" secondAttribute="top" constant="32" id="spH-p2-WWn"/>
+                            <constraint firstItem="XuD-5u-8XF" firstAttribute="centerY" secondItem="Hhx-Cv-PGe" secondAttribute="centerY" id="tXV-Ss-pvX"/>
+                            <constraint firstAttribute="trailing" secondItem="15f-PE-8sp" secondAttribute="trailing" constant="32" id="uck-yn-Q7k"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="XxM-Qk-9Cl"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Receive" id="q9F-2z-sCW"/>
+                    <connections>
+                        <outlet property="cancelButton" destination="S6t-Wl-g2c" id="dtO-rQ-zP2"/>
+                        <outlet property="hintLabel" destination="15f-PE-8sp" id="gqx-zU-X1d"/>
+                        <outlet property="loadingImageView" destination="XuD-5u-8XF" id="BKn-bI-VbJ"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="HgD-aY-2Gz" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="189" y="-698"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="GO_1" width="174" height="174"/>
+    </resources>
 </document>

--- a/POSMerchant/ViewControllers/KeypadInputViewController.swift
+++ b/POSMerchant/ViewControllers/KeypadInputViewController.swift
@@ -86,6 +86,10 @@ class KeypadInputViewController: BaseViewController {
             self?.actionButton!.isEnabled = $0
             self?.actionButton!.alpha = $0 ? 1 : 0.5
         }
+        self.viewModel.onInvalidQRCodeFormat = { [weak self] in
+            self?.dismiss(animated: true, completion: nil)
+            self?.showError(withMessage: $0.message)
+        }
     }
 }
 

--- a/POSMerchant/ViewControllers/MoreTableViewController.swift
+++ b/POSMerchant/ViewControllers/MoreTableViewController.swift
@@ -10,16 +10,20 @@ import UIKit
 
 class MoreTableViewController: BaseTableViewController {
     let accountsSegueIdentifier = "showAccountsViewController"
+    let exchangeAccountsSegueIdentifier = "showExchangeAccountsViewController"
     let transactionsSegueIdentifier = "showTransactionsViewController"
     let touchIdConfirmationSegueIdentifier = "showTouchIdConfirmationViewController"
 
     @IBOutlet var transactionLabel: UILabel!
     @IBOutlet var accountLabel: UILabel!
     @IBOutlet var accountValueLabel: UILabel!
+    @IBOutlet var exchangeAccountLabel: UILabel!
+    @IBOutlet var exchangeAccountValueLabel: UILabel!
     @IBOutlet var touchFaceIdLabel: UILabel!
     @IBOutlet var touchFaceIdSwitch: UISwitch!
     @IBOutlet var signOutLabel: UILabel!
     @IBOutlet var versionLabel: UILabel!
+    @IBOutlet var versionValueLabel: UILabel!
 
     private var viewModel: MoreTableViewModelProtocol = MoreTableViewModel()
 
@@ -35,10 +39,13 @@ class MoreTableViewController: BaseTableViewController {
         self.transactionLabel.text = self.viewModel.transactionLabelText
         self.accountLabel.text = self.viewModel.accountLabelText
         self.accountValueLabel.text = self.viewModel.accountValueLabelText
+        self.exchangeAccountLabel.text = self.viewModel.exchangeAccountLabelText
+        self.exchangeAccountValueLabel.text = self.viewModel.exchangeAccountValueLabelText
         self.touchFaceIdLabel.text = self.viewModel.touchFaceIdLabelText
         self.touchFaceIdSwitch.isOn = self.viewModel.switchState
         self.signOutLabel.text = self.viewModel.signOutLabelText
-        self.versionLabel.text = self.viewModel.currentVersion
+        self.versionLabel.text = self.viewModel.versionLabelText
+        self.versionValueLabel.text = self.viewModel.currentVersion
     }
 
     override func configureViewModel() {
@@ -58,6 +65,19 @@ class MoreTableViewController: BaseTableViewController {
         }
         self.viewModel.onAccountUpdate = { [weak self] in
             self?.accountValueLabel.text = self?.viewModel.accountValueLabelText
+        }
+        self.viewModel.onExchangeAccountUpdate = { [weak self] in
+            self?.exchangeAccountValueLabel.text = self?.viewModel.exchangeAccountValueLabelText
+        }
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender _: Any?) {
+        if segue.identifier == self.exchangeAccountsSegueIdentifier,
+            let vc = segue.destination as? SelectAccountTableViewController {
+            vc.viewModel = SelectAccountViewModel(mode: .exchangeAccount, delegate: self.viewModel)
+        } else if segue.identifier == self.accountsSegueIdentifier,
+            let vc = segue.destination as? SelectAccountTableViewController {
+            vc.viewModel = SelectAccountViewModel(mode: .currentAccount, delegate: self.viewModel)
         }
     }
 
@@ -82,9 +102,11 @@ extension MoreTableViewController {
         switch (indexPath.section, indexPath.row) {
         case (0, 0): // accounts
             self.performSegue(withIdentifier: self.accountsSegueIdentifier, sender: nil)
-        case (0, 1): // transactions
+        case (0, 1): // exchange account
+            self.performSegue(withIdentifier: self.exchangeAccountsSegueIdentifier, sender: nil)
+        case (0, 2): // transactions
             self.performSegue(withIdentifier: self.transactionsSegueIdentifier, sender: nil)
-        case (1, 0): // Sign out
+        case (2, 0): // Sign out
             self.viewModel.logout()
         default:
             break
@@ -95,6 +117,15 @@ extension MoreTableViewController {
         switch (indexPath.section, indexPath.row) {
         case (0, 2) where !self.viewModel.isBiometricAvailable: return 0
         default: return super.tableView(tableView, heightForRowAt: indexPath)
+        }
+    }
+
+    override func tableView(_: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch section {
+        case 0: return self.viewModel.settingsSectionTitle
+        case 1: return self.viewModel.infoSectionTitle
+        default:
+            return nil
         }
     }
 }

--- a/POSMerchant/ViewControllers/MoreTableViewController.swift
+++ b/POSMerchant/ViewControllers/MoreTableViewController.swift
@@ -98,6 +98,16 @@ extension MoreTableViewController {
 }
 
 extension MoreTableViewController {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = super.tableView(tableView, cellForRowAt: indexPath)
+        switch (indexPath.section, indexPath.row) {
+        case (0, 2) where !self.viewModel.isBiometricAvailable: // transactions
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        default: break
+        }
+        return cell
+    }
+
     override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch (indexPath.section, indexPath.row) {
         case (0, 0): // accounts
@@ -115,7 +125,7 @@ extension MoreTableViewController {
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         switch (indexPath.section, indexPath.row) {
-        case (0, 2) where !self.viewModel.isBiometricAvailable: return 0
+        case (0, 3) where !self.viewModel.isBiometricAvailable: return 0
         default: return super.tableView(tableView, heightForRowAt: indexPath)
         }
     }

--- a/POSMerchant/ViewControllers/SelectAccountTableViewController.swift
+++ b/POSMerchant/ViewControllers/SelectAccountTableViewController.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 class SelectAccountTableViewController: BaseTableViewController {
-    private var viewModel: SelectAccountViewModelProtocol = SelectAccountViewModel()
+    var viewModel: SelectAccountViewModelProtocol!
 
-    class func initWithViewModel(_ viewModel: SelectAccountViewModelProtocol = SelectAccountViewModel())
+    class func initWithViewModel(_ viewModel: SelectAccountViewModelProtocol)
         -> SelectAccountTableViewController? {
         guard let transactionsVC: SelectAccountTableViewController = Storyboard.selectAccount.viewControllerFromId() else { return nil }
         transactionsVC.viewModel = viewModel

--- a/POSMerchant/ViewControllers/SigninViewController.swift
+++ b/POSMerchant/ViewControllers/SigninViewController.swift
@@ -54,6 +54,14 @@ class SigninViewController: BaseViewController {
         }
     }
 
+    override func prepare(for segue: UIStoryboardSegue, sender _: Any?) {
+        if segue.identifier == self.showAccountSelectionSegueIdentifier,
+            let navVC = segue.destination as? UINavigationController,
+            let vc = navVC.viewControllers.first as? SelectAccountTableViewController {
+            vc.viewModel = SelectAccountViewModel(mode: .currentAccount)
+        }
+    }
+
     private func setupBioLoginButton() {
         guard self.viewModel.isBiometricAvailable else {
             self.bioLoginButton.isHidden = true

--- a/POSMerchant/ViewControllers/TransactionConfirmationViewController.swift
+++ b/POSMerchant/ViewControllers/TransactionConfirmationViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class TransactionConfirmationViewController: BaseViewController {
     var viewModel: TransactionConfirmationViewModelProtocol!
     private let showTransactionResultSegueId = "showTransactionResultSegueIdentifier"
+    private let showPendingConfirmationSegueId = "showPendingConfirmationSegueIdentifier"
 
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var tokenLabel: UILabel!
@@ -19,6 +20,7 @@ class TransactionConfirmationViewController: BaseViewController {
     @IBOutlet var userIdLabel: UILabel!
     @IBOutlet var confirmButton: UIButton!
     @IBOutlet var cancelButton: UIButton!
+    @IBOutlet var userDisplayAmount: UILabel!
 
     class func initWithViewModel(_ viewModel: TransactionConfirmationViewModelProtocol) -> TransactionConfirmationViewController? {
         guard let transactionConfirmationVC: TransactionConfirmationViewController =
@@ -38,8 +40,9 @@ class TransactionConfirmationViewController: BaseViewController {
         self.cancelButton.setTitle(self.viewModel.cancel, for: .normal)
         self.confirmButton.isEnabled = self.viewModel.isReady
         self.confirmButton.alpha = self.viewModel.isReady ? 1 : 0.5
+        self.userDisplayAmount.text = self.viewModel.userExpectedAmountDisplay
 
-        self.viewModel.loadUser()
+        self.viewModel.loadTransactionRequest()
     }
 
     override func viewDidLayoutSubviews() {
@@ -52,18 +55,30 @@ class TransactionConfirmationViewController: BaseViewController {
         self.viewModel.onLoadStateChange = { [weak self] in
             $0 ? self?.showLoading() : self?.hideLoading()
         }
-        self.viewModel.onSuccessGetUser = { [weak self] in
+        self.viewModel.onSuccessGetTransactionRequest = { [weak self] in
             self?.usernameLabel.text = self?.viewModel.username
             self?.userIdLabel.text = self?.viewModel.userId
+            self?.userDisplayAmount.text = self?.viewModel.userExpectedAmountDisplay
             self?.updateButtonState()
         }
-        self.viewModel.onFailGetUser = { [weak self] in
+        self.viewModel.onFailGetTransactionRequest = { [weak self] in
             self?.showError(withMessage: $0.localizedDescription)
             self?.navigationController?.popViewController(animated: true)
         }
-        self.viewModel.onCreateTransactionComplete = { [weak self] in
+        self.viewModel.onPendingConsumptionConfirmation = { [weak self] in
             guard let weakself = self else { return }
-            weakself.performSegue(withIdentifier: weakself.showTransactionResultSegueId, sender: $0)
+            weakself.performSegue(withIdentifier: weakself.showPendingConfirmationSegueId, sender: nil)
+        }
+        self.viewModel.onCompletedConsumption = { [weak self] transactionBuilder in
+            guard let weakself = self else { return }
+            weakself.viewModel.stopListening()
+            if let viewController = weakself.presentedViewController, !viewController.isBeingDismissed {
+                viewController.dismiss(animated: true, completion: {
+                    weakself.performSegue(withIdentifier: weakself.showTransactionResultSegueId, sender: transactionBuilder)
+                })
+            } else {
+                weakself.performSegue(withIdentifier: weakself.showTransactionResultSegueId, sender: transactionBuilder)
+            }
         }
     }
 
@@ -72,6 +87,9 @@ class TransactionConfirmationViewController: BaseViewController {
             let transactionResultVC = segue.destination as? TransactionResultViewController,
             let transactionBuilder = sender as? TransactionBuilder {
             transactionResultVC.viewModel = TransactionResultViewModel(transactionBuilder: transactionBuilder)
+        } else if segue.identifier == self.showPendingConfirmationSegueId,
+            let vc = segue.destination as? WaitingForUserConfirmationViewController {
+            vc.delegate = self.viewModel
         }
     }
 
@@ -87,6 +105,7 @@ extension TransactionConfirmationViewController {
     }
 
     @IBAction func tapCancelButton(_: UIButton) {
+        self.viewModel.stopListening()
         self.navigationController?.popViewController(animated: true)
     }
 }

--- a/POSMerchant/ViewControllers/WaitingForUserConfirmationViewController.swift
+++ b/POSMerchant/ViewControllers/WaitingForUserConfirmationViewController.swift
@@ -1,0 +1,46 @@
+//
+//  WaitingForUserConfirmationViewController.swift
+//  POSMerchant
+//
+//  Created by Mederic Petit on 10/10/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+protocol WaitingForUserConfirmationViewControllerDelegate: class {
+    func waitingForUserConfirmationDidCancel()
+}
+
+class WaitingForUserConfirmationViewController: BaseViewController {
+    @IBOutlet var hintLabel: UILabel!
+    @IBOutlet var cancelButton: UIButton!
+    @IBOutlet var loadingImageView: UIImageView!
+
+    weak var delegate: WaitingForUserConfirmationViewControllerDelegate?
+
+    override func configureView() {
+        super.configureView()
+        self.hintLabel.text = "waiting_confirmation.label.hint".localized()
+        self.buildAnimation()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        self.cancelButton.addBorder(withColor: Color.redError.uiColor(), width: 1, radius: 4)
+    }
+
+    private func buildAnimation() {
+        var images: [UIImage] = []
+        for n in 1 ... 52 {
+            images.append(UIImage(named: "GO_\(n)")!)
+        }
+        self.loadingImageView.animationImages = images
+        self.loadingImageView.startAnimating()
+    }
+
+    @IBAction func tapCancelButton(_: Any) {
+        self.delegate?.waitingForUserConfirmationDidCancel()
+        self.dismiss(animated: true, completion: nil)
+    }
+}

--- a/POSMerchant/ViewModelProtocols/KeypadInputViewModelProtocol.swift
+++ b/POSMerchant/ViewModelProtocols/KeypadInputViewModelProtocol.swift
@@ -21,6 +21,7 @@ protocol KeypadInputViewModelProtocol: KeyboardEventDelegate, SelectTokenDelegat
     var onFailGetDefaultToken: FailureClosure? { get set }
     var onReadyStateChange: ObjectClosure<Bool>? { get set }
     var onAmountValidationChange: ObjectClosure<Bool>? { get set }
+    var onInvalidQRCodeFormat: FailureClosure? { get set }
     var shouldProcessTransaction: ObjectClosure<TransactionBuilder>? { get set }
 
     func resetAmount()

--- a/POSMerchant/ViewModelProtocols/MoreTableViewModelProtocol.swift
+++ b/POSMerchant/ViewModelProtocols/MoreTableViewModelProtocol.swift
@@ -8,22 +8,28 @@
 
 import UIKit
 
-protocol MoreTableViewModelProtocol {
+protocol MoreTableViewModelProtocol: SelectAccountViewModelDelegate {
     var title: String { get }
     var transactionLabelText: String { get }
     var accountLabelText: String { get }
+    var exchangeAccountLabelText: String { get }
     var signOutLabelText: String { get }
+    var settingsSectionTitle: String { get }
+    var infoSectionTitle: String { get }
+    var versionLabelText: String { get }
 
     var onFailLogout: FailureClosure? { get set }
     var onLoadStateChange: ObjectClosure<Bool>? { get set }
     var shouldShowEnableConfirmationView: EmptyClosure? { get set }
     var onBioStateChange: ObjectClosure<Bool>? { get set }
     var onAccountUpdate: EmptyClosure? { get set }
+    var onExchangeAccountUpdate: EmptyClosure? { get set }
 
     var switchState: Bool { get set }
     var isBiometricAvailable: Bool { get }
     var touchFaceIdLabelText: String { get }
     var accountValueLabelText: String { get }
+    var exchangeAccountValueLabelText: String { get }
     var currentVersion: String { get }
 
     func toggleSwitch(newValue isEnabled: Bool)

--- a/POSMerchant/ViewModelProtocols/SelectAccountViewModelProtocol.swift
+++ b/POSMerchant/ViewModelProtocols/SelectAccountViewModelProtocol.swift
@@ -13,8 +13,14 @@ protocol SelectAccountViewModelProtocol {
     var reloadTableViewClosure: EmptyClosure? { get set }
     var onFailLoadAccounts: FailureClosure? { get set }
     var onLoadStateChange: ObjectClosure<Bool>? { get set }
+    var delegate: SelectAccountViewModelDelegate? { get set }
 
     var viewTitle: String { get }
+
+    init(accountLoader: AccountLoaderProtocol,
+         sessionManager: SessionManagerProtocol,
+         mode: SelectAccountMode,
+         delegate: SelectAccountViewModelDelegate?)
 
     func reloadAccounts()
     func getNextAccounts()

--- a/POSMerchant/ViewModelProtocols/TransactionConfirmationViewModelProtocol.swift
+++ b/POSMerchant/ViewModelProtocols/TransactionConfirmationViewModelProtocol.swift
@@ -8,26 +8,29 @@
 
 import OmiseGO
 
-protocol TransactionConfirmationViewModelProtocol {
-    var onSuccessGetUser: SuccessClosure? { get set }
-    var onFailGetUser: FailureClosure? { get set }
-    var onCreateTransactionComplete: ObjectClosure<TransactionBuilder>? { get set }
+protocol TransactionConfirmationViewModelProtocol: WaitingForUserConfirmationViewControllerDelegate {
+    var onSuccessGetTransactionRequest: SuccessClosure? { get set }
+    var onFailGetTransactionRequest: FailureClosure? { get set }
     var onLoadStateChange: ObjectClosure<Bool>? { get set }
+    var onCompletedConsumption: ObjectClosure<TransactionBuilder>? { get set }
+    var onPendingConsumptionConfirmation: EmptyClosure? { get set }
 
     var title: String { get }
     var direction: String { get }
     var amountDisplay: String { get }
     var confirm: String { get }
     var cancel: String { get }
-    var isReady: Bool { get set }
-    var username: String { get set }
-    var userId: String { get set }
+    var isReady: Bool { get }
+    var username: String { get }
+    var userId: String { get }
+    var userExpectedAmountDisplay: String { get }
 
     init(sessionManager: SessionManagerProtocol,
          walletLoader: WalletLoaderProtocol,
-         transactionGenerator: TransactionGeneratorProtocol,
+         transactionConsumptionGenerator: TransactionConsumptionGeneratorProtocol,
          transactionBuilder: TransactionBuilder)
 
-    func loadUser()
+    func loadTransactionRequest()
     func performTransaction()
+    func stopListening()
 }

--- a/POSMerchant/ViewModels/KeypadInputViewModel.swift
+++ b/POSMerchant/ViewModels/KeypadInputViewModel.swift
@@ -41,6 +41,7 @@ class KeypadInputViewModel: BaseViewModel, KeypadInputViewModelProtocol {
     var onReadyStateChange: ObjectClosure<Bool>?
     var onAmountValidationChange: ObjectClosure<Bool>?
     var shouldProcessTransaction: ObjectClosure<TransactionBuilder>?
+    var onInvalidQRCodeFormat: FailureClosure?
     var selectedToken: Token? {
         didSet {
             self.tokenString = self.selectedToken?.name ?? "-"

--- a/POSMerchant/ViewModels/MoreTableViewModel.swift
+++ b/POSMerchant/ViewModels/MoreTableViewModel.swift
@@ -6,20 +6,26 @@
 //  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
 //
 
-import UIKit
+import OmiseGO
 
 class MoreTableViewModel: BaseViewModel, MoreTableViewModelProtocol {
     let title = "more.view.title".localized()
     let transactionLabelText = "more.label.transactions".localized()
     let accountLabelText = "more.label.account".localized()
     let signOutLabelText = "more.label.signout".localized()
-    let currentVersion = "v \(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? "")"
+    let exchangeAccountLabelText = "more.label.exchange_account".localized()
+    let currentVersion = "v\(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? "")"
+
+    let settingsSectionTitle = "more.section.settings".localized()
+    let infoSectionTitle = "more.section.info".localized()
+    let versionLabelText = "more.label.version".localized()
 
     var onFailLogout: FailureClosure?
     var onLoadStateChange: ObjectClosure<Bool>?
     var shouldShowEnableConfirmationView: EmptyClosure?
     var onBioStateChange: ObjectClosure<Bool>?
     var onAccountUpdate: EmptyClosure?
+    var onExchangeAccountUpdate: EmptyClosure?
 
     var switchState: Bool {
         didSet {
@@ -41,6 +47,10 @@ class MoreTableViewModel: BaseViewModel, MoreTableViewModelProtocol {
 
     lazy var accountValueLabelText: String = {
         self.sessionManager.selectedAccount?.name ?? ""
+    }()
+
+    lazy var exchangeAccountValueLabelText: String = {
+        UserDefaultsWrapper().getValue(forKey: .exchangeAccountName) ?? ""
     }()
 
     private let sessionManager: SessionManagerProtocol
@@ -68,6 +78,17 @@ class MoreTableViewModel: BaseViewModel, MoreTableViewModelProtocol {
     func stopObserving() {
         self.sessionManager.removeObserver(observer: self)
     }
+
+    func didSelectAccount(account: Account, forMode mode: SelectAccountMode) {
+        switch mode {
+        case .exchangeAccount:
+            self.exchangeAccountValueLabelText = account.name
+            self.onExchangeAccountUpdate?()
+        case .currentAccount:
+            self.accountValueLabelText = self.sessionManager.selectedAccount?.name ?? ""
+            self.onAccountUpdate?()
+        }
+    }
 }
 
 extension MoreTableViewModel: Observer {
@@ -75,9 +96,6 @@ extension MoreTableViewModel: Observer {
         switch event {
         case let .onBioStateUpdate(enabled: enabled):
             self.switchState = enabled
-        case .onSelectedAccountUpdate:
-            self.accountValueLabelText = self.sessionManager.selectedAccount?.name ?? ""
-            self.onAccountUpdate?()
         default: break
         }
     }

--- a/POSMerchant/ViewModels/ReceiveViewModel.swift
+++ b/POSMerchant/ViewModels/ReceiveViewModel.swift
@@ -18,10 +18,12 @@ class ReceiveViewModel: KeypadInputViewModel {
     }
 
     override func didDecode(_ string: String) {
-        let transactionBuilder = TransactionBuilder(type: .receive,
-                                                    amount: self.displayAmount,
-                                                    token: self.selectedToken!,
-                                                    address: string)
+        guard let transactionBuilder = TransactionBuilder(type: .receive,
+                                                          amount: self.displayAmount,
+                                                          token: self.selectedToken!,
+                                                          decodedString: string) else {
+            self.onInvalidQRCodeFormat?(.message(message: "keypad_input.error.invalid_qr_code".localized()))
+            return }
         self.shouldProcessTransaction?(transactionBuilder)
     }
 

--- a/POSMerchant/ViewModels/SigninViewModel.swift
+++ b/POSMerchant/ViewModels/SigninViewModel.swift
@@ -19,7 +19,7 @@ class SigninViewModel: BaseViewModel, SigninViewModelProtocol {
     let emailPlaceholder = "sign_in.text_field.placeholder.email".localized()
     let passwordPlaceholder = "sign_in.text_field.placeholder.password".localized()
     let loginButtonTitle = "sign_in.button.title.login".localized()
-    let currentVersion = "v \(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? "")"
+    let currentVersion = "v\(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? "")"
 
     var email: String? {
         didSet { self.validateEmail() }

--- a/POSMerchant/ViewModels/TopUpViewModel.swift
+++ b/POSMerchant/ViewModels/TopUpViewModel.swift
@@ -18,10 +18,12 @@ class TopUpViewModel: KeypadInputViewModel {
     }
 
     override func didDecode(_ string: String) {
-        let transactionBuilder = TransactionBuilder(type: .topup,
-                                                    amount: self.displayAmount,
-                                                    token: self.selectedToken!,
-                                                    address: string)
+        guard let transactionBuilder = TransactionBuilder(type: .topup,
+                                                          amount: self.displayAmount,
+                                                          token: self.selectedToken!,
+                                                          decodedString: string) else {
+            self.onInvalidQRCodeFormat?(.message(message: "keypad_input.error.invalid_qr_code".localized()))
+            return }
         self.shouldProcessTransaction?(transactionBuilder)
     }
 

--- a/POSMerchant/ViewModels/TransactionResultViewModel.swift
+++ b/POSMerchant/ViewModels/TransactionResultViewModel.swift
@@ -30,21 +30,20 @@ class TransactionResultViewModel: BaseViewModel, TransactionResultViewModelProto
         self.username = transactionBuilder.user!.email ?? "-"
         self.userId = transactionBuilder.user!.id
         self.done = "transaction_result.done".localized()
-        switch transactionBuilder.result! {
-        case .success:
-            self.statusImage = UIImage(named: "Completed")!
-            self.statusImageColor = Color.lightBlue.uiColor()
-            self.status = self.transactionBuilder.type == .receive ?
-                "transaction_result.payment_successful".localized() :
-                "transaction_result.topup_successful".localized()
-            self.error = ""
-        case let .fail(error: error):
+        if let error = transactionBuilder.error {
             self.statusImage = UIImage(named: "Failed")!
             self.statusImageColor = Color.redError.uiColor()
             self.status = self.transactionBuilder.type == .receive ?
                 "transaction_result.payment_failed".localized() :
                 "transaction_result.topup_failed".localized()
             self.error = error.message
+        } else {
+            self.statusImage = UIImage(named: "Completed")!
+            self.statusImageColor = Color.lightBlue.uiColor()
+            self.status = self.transactionBuilder.type == .receive ?
+                "transaction_result.payment_successful".localized() :
+                "transaction_result.topup_successful".localized()
+            self.error = ""
         }
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ target 'POSMerchant' do
   pod 'TPKeyboardAvoiding'
   pod 'SkyFloatingLabelTextField'
   pod 'AlamofireImage'
-  pod 'OmiseGO/Admin', git: 'https://github.com/omisego/ios-sdk.git'
+  pod 'OmiseGO/Admin', git: 'https://github.com/omisego/ios-sdk.git', branch: '101-transaction-request'
 
   target 'POSMerchantTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - Starscream (~> 3.0)
   - SipHash (1.2.2)
   - SkyFloatingLabelTextField (3.6.0)
-  - Starscream (3.0.5)
+  - Starscream (3.0.6)
   - Toaster (2.1.1)
   - TPKeyboardAvoiding (1.3.2)
 
@@ -23,7 +23,7 @@ DEPENDENCIES:
   - BigInt
   - KeychainAccess
   - MBProgressHUD
-  - OmiseGO/Admin (from `https://github.com/omisego/ios-sdk.git`)
+  - OmiseGO/Admin (from `https://github.com/omisego/ios-sdk.git`, branch `101-transaction-request`)
   - SkyFloatingLabelTextField
   - Toaster
   - TPKeyboardAvoiding
@@ -43,11 +43,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   OmiseGO:
+    :branch: 101-transaction-request
     :git: https://github.com/omisego/ios-sdk.git
 
 CHECKOUT OPTIONS:
   OmiseGO:
-    :commit: e3c3cd7dc35fdaa708111d0ce0db2f0d48d49349
+    :commit: 44c19aabe95768071efd51416eae36860e161481
     :git: https://github.com/omisego/ios-sdk.git
 
 SPEC CHECKSUMS:
@@ -59,10 +60,10 @@ SPEC CHECKSUMS:
   OmiseGO: ae5b3c451ad1535293365a0285d7d784b8d20221
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   SkyFloatingLabelTextField: 38164979b79512f9ff9288ad8acfc4bbf5d843e3
-  Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
+  Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   Toaster: a6c9532de1ded8105e77376f7dffeb2e12b46dbb
   TPKeyboardAvoiding: cb69d5ddbe90ce0170e4bc2db1e5e41d4a3ad9a4
 
-PODFILE CHECKSUM: 1d04db34594dac77229204f15c0150db2abc4642
+PODFILE CHECKSUM: 0e28711abf51c4844b6000bd81145dd357911bd4
 
 COCOAPODS: 1.6.0.beta.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - Alamofire (~> 4.7)
   - BigInt (3.1.0):
     - SipHash (~> 1.2)
-  - KeychainAccess (3.1.1)
+  - KeychainAccess (3.1.2)
   - MBProgressHUD (1.1.0)
   - OmiseGO/Admin (1.1.0-beta1):
     - OmiseGO/Core
@@ -48,16 +48,16 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   OmiseGO:
-    :commit: 44c19aabe95768071efd51416eae36860e161481
+    :commit: 4854fba440a4aae3eda0d2f07157c292d977121d
     :git: https://github.com/omisego/ios-sdk.git
 
 SPEC CHECKSUMS:
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   AlamofireImage: 78d67ccbb763d87ba44b21583d2153500a195630
   BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
-  KeychainAccess: 7bd430028059754a3debab3cfc0bd1fc7fb85df3
+  KeychainAccess: b3816fddcf28aa29d94b10ec305cd52be14c472b
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  OmiseGO: ae5b3c451ad1535293365a0285d7d784b8d20221
+  OmiseGO: d0e97b58270017ebd9ab3c689178b8d7c5fc2941
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   SkyFloatingLabelTextField: 38164979b79512f9ff9288ad8acfc4bbf5d843e3
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
@@ -66,4 +66,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 0e28711abf51c4844b6000bd81145dd357911bd4
 
-COCOAPODS: 1.6.0.beta.1
+COCOAPODS: 1.5.3


### PR DESCRIPTION
Closes #19 

# Overview

This PR changes the way transactions are performed by using transactions requests instead of simple transactions.
This new flow improves security of the user's funds as he will need to confirm the debit transactions.

The planned flow is as follow:
- The client app generates 2 transaction requests upon login, or when the user picks a different token, 1 `receive` and 1 `send`. The `send` requires a confirmation.
- We encode the id of these 2 requests inside the QR code displayed to the merchant.
- When the merchant scans, we retrieve the 2 ids from the QR code and get the detail of the request according to the transaction chosen (top-up or receive).
- If it's a top-up, the user does not need to confirm as we are sending him tokens.
- If it's a receive, the user will receive a confirmation request via websockets and the merchant app will listen for incoming events on the request.
- Transaction will be completed when the user approves or rejects the confirmation.