### PR TITLE
Update with latest OmiseGO SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: swift
 osx_image: xcode10
+cache: cocoapods
+xcode_workspace: POSMerchant.xcworkspace
+xcode_scheme: POSMerchant
+xcode_destination: platform=iOS Simulator,name=iPhone X
 before_install:
   pod repo update
-script:
-  set -o pipefail &&
-  xcodebuild -workspace POSMerchant.xcworkspace -scheme "POSMerchant" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone X" test | xcpretty ;

--- a/POSMerchant.xcodeproj/project.pbxproj
+++ b/POSMerchant.xcodeproj/project.pbxproj
@@ -869,11 +869,11 @@
 				"${BUILT_PRODUCTS_DIR}/KeychainAccess/KeychainAccess.framework",
 				"${BUILT_PRODUCTS_DIR}/MBProgressHUD/MBProgressHUD.framework",
 				"${BUILT_PRODUCTS_DIR}/OmiseGO/OmiseGO.framework",
+				"${BUILT_PRODUCTS_DIR}/SBToaster/SBToaster.framework",
 				"${BUILT_PRODUCTS_DIR}/SipHash/SipHash.framework",
 				"${BUILT_PRODUCTS_DIR}/SkyFloatingLabelTextField/SkyFloatingLabelTextField.framework",
 				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
 				"${BUILT_PRODUCTS_DIR}/TPKeyboardAvoiding/TPKeyboardAvoiding.framework",
-				"${BUILT_PRODUCTS_DIR}/Toaster/Toaster.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -883,11 +883,11 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KeychainAccess.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MBProgressHUD.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OmiseGO.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SBToaster.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SipHash.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SkyFloatingLabelTextField.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TPKeyboardAvoiding.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toaster.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/POSMerchant/Helpers/BaseViewControllerProtocols.swift
+++ b/POSMerchant/Helpers/BaseViewControllerProtocols.swift
@@ -7,7 +7,7 @@
 //
 
 import MBProgressHUD
-import Toaster
+import SBToaster
 
 protocol Configurable {
     func configureView()

--- a/POSMerchant/Info.plist
+++ b/POSMerchant/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/POSMerchant/ViewModels/KeypadInputViewModel.swift
+++ b/POSMerchant/ViewModels/KeypadInputViewModel.swift
@@ -76,9 +76,10 @@ class KeypadInputViewModel: BaseViewModel, KeypadInputViewModelProtocol {
     }
 
     func loadDefaultToken() {
+        let primaryFilter = Wallet.filter(field: .identifier, comparator: .equal, value: "primary")
         let paginationParams = PaginatedListParams<Wallet>(page: 1,
                                                            perPage: 1,
-                                                           searchTerms: [.identifier: "primary"],
+                                                           filters: FilterParams(matchAll: [primaryFilter]),
                                                            sortBy: .address,
                                                            sortDirection: .ascending)
         let params = WalletListForAccountParams(paginatedListParams: paginationParams,

--- a/POSMerchant/ViewModels/MoreTableViewModel.swift
+++ b/POSMerchant/ViewModels/MoreTableViewModel.swift
@@ -14,7 +14,7 @@ class MoreTableViewModel: BaseViewModel, MoreTableViewModelProtocol {
     let accountLabelText = "more.label.account".localized()
     let signOutLabelText = "more.label.signout".localized()
     let exchangeAccountLabelText = "more.label.exchange_account".localized()
-    let currentVersion = "v \(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? "")"
+    let currentVersion = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? ""
 
     let settingsSectionTitle = "more.section.settings".localized()
     let infoSectionTitle = "more.section.info".localized()

--- a/POSMerchant/ViewModels/SelectTokenViewModel.swift
+++ b/POSMerchant/ViewModels/SelectTokenViewModel.swift
@@ -49,9 +49,10 @@ class SelectTokenViewModel: BaseViewModel, SelectTokenViewModelProtocol {
 
     func loadBalances() {
         self.isLoading = true
+        let primaryFilter = Wallet.filter(field: .identifier, comparator: .equal, value: "primary")
         let paginationParams = PaginatedListParams<Wallet>(page: 1,
                                                            perPage: 1,
-                                                           searchTerms: [.identifier: "primary"],
+                                                           filters: FilterParams(matchAll: [primaryFilter]),
                                                            sortBy: .address,
                                                            sortDirection: .ascending)
         let params = WalletListForAccountParams(paginatedListParams: paginationParams,

--- a/POSMerchant/ViewModels/SigninViewModel.swift
+++ b/POSMerchant/ViewModels/SigninViewModel.swift
@@ -19,7 +19,7 @@ class SigninViewModel: BaseViewModel, SigninViewModelProtocol {
     let emailPlaceholder = "sign_in.text_field.placeholder.email".localized()
     let passwordPlaceholder = "sign_in.text_field.placeholder.password".localized()
     let loginButtonTitle = "sign_in.button.title.login".localized()
-    let currentVersion = "v \(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? "")"
+    let currentVersion = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? ""
 
     var email: String? {
         didSet { self.validateEmail() }

--- a/POSMerchantTests/ViewControllers/LoadingViewControllerTests.swift
+++ b/POSMerchantTests/ViewControllers/LoadingViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSMerchant
-import Toaster
+import SBToaster
 import XCTest
 
 class LoadingViewControllerTests: XCTestCase {

--- a/POSMerchantTests/ViewControllers/MoreTableViewControllerTests.swift
+++ b/POSMerchantTests/ViewControllers/MoreTableViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSMerchant
-import Toaster
+import SBToaster
 import XCTest
 
 class MoreTableViewControllerTests: XCTestCase {

--- a/POSMerchantTests/ViewControllers/SelectAccountViewContollerTests.swift
+++ b/POSMerchantTests/ViewControllers/SelectAccountViewContollerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSMerchant
-import Toaster
+import SBToaster
 import XCTest
 
 class SelectAccountViewContollerTests: XCTestCase {

--- a/POSMerchantTests/ViewControllers/SigninViewControllerTests.swift
+++ b/POSMerchantTests/ViewControllers/SigninViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSMerchant
-import Toaster
+import SBToaster
 import XCTest
 
 class SigninViewControllerTests: XCTestCase {

--- a/POSMerchantTests/ViewControllers/TouchIDConfirmationViewControllerTests.swift
+++ b/POSMerchantTests/ViewControllers/TouchIDConfirmationViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSMerchant
-import Toaster
+import SBToaster
 import XCTest
 
 class TouchIDConfirmationViewControllerTests: XCTestCase {

--- a/POSMerchantTests/ViewControllers/TransactionConfirmationViewControllerTests.swift
+++ b/POSMerchantTests/ViewControllers/TransactionConfirmationViewControllerTests.swift
@@ -8,7 +8,7 @@
 
 import OmiseGO
 @testable import POSMerchant
-import Toaster
+import SBToaster
 import XCTest
 
 class TransactionConfirmationViewControllerTests: XCTestCase {

--- a/POSMerchantTests/ViewControllers/TransactionsViewControllerTests.swift
+++ b/POSMerchantTests/ViewControllers/TransactionsViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSMerchant
-import Toaster
+import SBToaster
 import XCTest
 
 class TransactionsViewControllerTests: XCTestCase {

--- a/POSMerchantTests/ViewModelTests/SelectTokenTableViewControllerTests.swift
+++ b/POSMerchantTests/ViewModelTests/SelectTokenTableViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSMerchant
-import Toaster
+import SBToaster
 import XCTest
 
 class SelectTokenTableViewControllerTests: XCTestCase {

--- a/Podfile
+++ b/Podfile
@@ -10,24 +10,14 @@ target 'POSMerchant' do
   pod 'KeychainAccess'
   pod 'BigInt'
   pod 'MBProgressHUD'
-  pod 'Toaster'
+  pod 'SBToaster'
   pod 'TPKeyboardAvoiding'
   pod 'SkyFloatingLabelTextField'
   pod 'AlamofireImage'
-  pod 'OmiseGO/Admin', '1.1.0-beta2'
+  pod 'OmiseGO/Admin', '~> 1.1.0'
 
   target 'POSMerchantTests' do
     inherit! :search_paths
     # Pods for testing
-  end
-end
-
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    if target.name == 'Toaster'
-      target.build_configurations.each do |config|
-        config.build_settings['SWIFT_VERSION'] = '4.0'
-      end
-    end
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
-  - Alamofire (4.7.3)
-  - AlamofireImage (3.4.1):
-    - Alamofire (~> 4.7)
+  - Alamofire (4.8.1)
+  - AlamofireImage (3.5.0):
+    - Alamofire (~> 4.8)
   - BigInt (3.1.0):
     - SipHash (~> 1.2)
   - KeychainAccess (3.1.2)
   - MBProgressHUD (1.1.0)
-  - OmiseGO/Admin (1.1.0-beta2):
+  - OmiseGO/Admin (1.1.0):
     - OmiseGO/Core
-  - OmiseGO/Core (1.1.0-beta2):
+  - OmiseGO/Core (1.1.0):
     - BigInt (~> 3.1)
     - Starscream (~> 3.0)
+  - SBToaster (2.1.2)
   - SipHash (1.2.2)
   - SkyFloatingLabelTextField (3.6.0)
   - Starscream (3.0.6)
-  - Toaster (2.1.1)
   - TPKeyboardAvoiding (1.3.2)
 
 DEPENDENCIES:
@@ -23,9 +23,9 @@ DEPENDENCIES:
   - BigInt
   - KeychainAccess
   - MBProgressHUD
-  - OmiseGO/Admin (= 1.1.0-beta2)
+  - OmiseGO/Admin (~> 1.1.0)
+  - SBToaster
   - SkyFloatingLabelTextField
-  - Toaster
   - TPKeyboardAvoiding
 
 SPEC REPOS:
@@ -36,25 +36,25 @@ SPEC REPOS:
     - KeychainAccess
     - MBProgressHUD
     - OmiseGO
+    - SBToaster
     - SipHash
     - SkyFloatingLabelTextField
     - Starscream
-    - Toaster
     - TPKeyboardAvoiding
 
 SPEC CHECKSUMS:
-  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
-  AlamofireImage: 78d67ccbb763d87ba44b21583d2153500a195630
+  Alamofire: 16ce2c353fb72865124ddae8a57c5942388f4f11
+  AlamofireImage: 1aea346f4dda2f6c67622fa5a89fcbb80d79cc16
   BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
   KeychainAccess: b3816fddcf28aa29d94b10ec305cd52be14c472b
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  OmiseGO: 1548d22049d99e650cba3dd3843d9ebf2af53d36
+  OmiseGO: 377bd1a344cc4e7bd5bba0e56e2b760a326837ef
+  SBToaster: ffea00ad8c38eb80e6800c0fee5bc9b4c184252b
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   SkyFloatingLabelTextField: 38164979b79512f9ff9288ad8acfc4bbf5d843e3
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
-  Toaster: a6c9532de1ded8105e77376f7dffeb2e12b46dbb
   TPKeyboardAvoiding: cb69d5ddbe90ce0170e4bc2db1e5e41d4a3ad9a4
 
-PODFILE CHECKSUM: 82f0d9bcdb9ec19aa4f57df100ccfb2c34778f72
+PODFILE CHECKSUM: f3f06e4a855327d31a3c9df199d4f36b9e8fefc5
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Closes #27 

# Overview

This PR mainly bumps the OmiseGO SDK version to `1.1.0` and updates the corresponding code.

# Changes

- Update Podfile to use the version `1.1.0` of the OmiseGO SDK
- Update Podfile and related files to use the forked `SBToaster` instead of `Toaster` which is not yet compatible with swift 4.2.
