### PR TITLE
Fix token loading and improve validation

### DIFF
--- a/POSMerchant/ViewModels/KeyboardViewModel.swift
+++ b/POSMerchant/ViewModels/KeyboardViewModel.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol KeyboardEventDelegate: class {
-    func didTapNumber(_ number: String)
+    func didTapNumber(_ number: String, keyboardViewModel: KeyboardViewModel)
     func didTapDecimalSeparator(_ character: Character)
     func didTapDelete()
 }
@@ -23,7 +23,7 @@ class KeyboardViewModel: BaseViewModel, KeyboardViewModelProtocol {
     }
 
     func tapNumber(_ number: Int) {
-        self.delegate?.didTapNumber(String(number))
+        self.delegate?.didTapNumber(String(number), keyboardViewModel: self)
     }
 
     func tapDecimalSeparator() {

--- a/POSMerchant/ViewModels/SelectTokenViewModel.swift
+++ b/POSMerchant/ViewModels/SelectTokenViewModel.swift
@@ -57,7 +57,7 @@ class SelectTokenViewModel: BaseViewModel, SelectTokenViewModelProtocol {
                                                            sortDirection: .ascending)
         let params = WalletListForAccountParams(paginatedListParams: paginationParams,
                                                 accountId: self.sessionManager.selectedAccount?.id ?? "",
-                                                owned: false)
+                                                owned: true)
         self.tokenLoader.listForAccount(withParams: params) { result in
             switch result {
             case let .success(data: paginatedWallets):

--- a/POSMerchantTests/ViewModelTests/KeyboardViewModelTests.swift
+++ b/POSMerchantTests/ViewModelTests/KeyboardViewModelTests.swift
@@ -55,7 +55,7 @@ class KeyboardViewModelTests: XCTestCase {
         var didTapDecimalSeparatorCalled: Character?
         var didTapDeleteCalled = false
 
-        func didTapNumber(_ number: String) {
+        func didTapNumber(_ number: String, keyboardViewModel _: KeyboardViewModel) {
             self.didTapNumberCalled = number
             self.expectation.fulfill()
         }

--- a/POSMerchantTests/ViewModelTests/KeypadInputViewModelTests.swift
+++ b/POSMerchantTests/ViewModelTests/KeypadInputViewModelTests.swift
@@ -77,7 +77,7 @@ class KeypadInputViewModelTests: XCTestCase {
         self.sut.onAmountUpdate = {
             amount = $0
         }
-        self.sut.didTapNumber("1")
+        self.sut.didTapNumber("1", keyboardViewModel: KeyboardViewModel(delegate: nil))
         XCTAssertEqual(amount, "1")
     }
 
@@ -87,7 +87,8 @@ class KeypadInputViewModelTests: XCTestCase {
         self.sut.onAmountUpdate = { _ in
             XCTFail("should not be called")
         }
-        self.sut.didTapNumber("0")
+
+        self.sut.didTapNumber("0", keyboardViewModel: KeyboardViewModel(delegate: nil))
         XCTAssertEqual(self.sut.displayAmount, initialAmount)
     }
 
@@ -97,8 +98,19 @@ class KeypadInputViewModelTests: XCTestCase {
         self.sut.onAmountUpdate = {
             amount = $0
         }
-        self.sut.didTapNumber("2")
+        self.sut.didTapNumber("2", keyboardViewModel: KeyboardViewModel(delegate: nil))
         XCTAssertEqual(amount, "12")
+    }
+
+    func testTapNumberWithHigherDecimalCountThanSelectedTokenIsNotAllowed() {
+        self.sut.selectedToken = StubGenerator.wallets().first!.balances.first!.token
+        XCTAssertEqual(self.sut.selectedToken?.subUnitToUnit, 100)
+        self.sut.displayAmount = "1.23"
+        self.sut.onAmountUpdate = { _ in
+            XCTFail("should not be called")
+        }
+        self.sut.didTapNumber("4", keyboardViewModel: KeyboardViewModel(delegate: nil))
+        XCTAssertEqual(self.sut.displayAmount, "1.23")
     }
 
     func testTapDesimalSeparatorWhenNotContainingYet() {
@@ -151,6 +163,13 @@ class KeypadInputViewModelTests: XCTestCase {
         }
         self.sut.didSelectToken(expectedToken)
         XCTAssertEqual(tokenStr, expectedToken.name)
+    }
+
+    func testSelectingTokenResetsAmount() {
+        let token = StubGenerator.wallets().first!.balances.first!.token
+        self.sut.displayAmount = "1.23"
+        self.sut.didSelectToken(token)
+        XCTAssertEqual(self.sut.displayAmount, "0")
     }
 
     func testResetAmount() {


### PR DESCRIPTION
# Overview

This PR 
- fixes the way the account wallets queried by using `owned: true`.
- Enhance the user experience when inputing a number on the numeric keyboard by limiting the number of decimals to the maximum number of decimals the selected token has. ie: If the selected token has a subunit to unit = `100` (2 decimals), the user can't input a number like `12.345`, but will be limited to `12.34`. 